### PR TITLE
#3 - Backend API 연동을 위한 Fetch 라이브러리 구현

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pf-dev/api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./types": "./src/types.ts",
+    "./error": "./src/error.ts"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "clean": "rimraf dist node_modules .turbo"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -1,0 +1,258 @@
+import { ApiError } from './error';
+import type { ApiClientConfig, RequestOptions, UploadOptions } from './types';
+
+/**
+ * API 클라이언트 생성
+ */
+export function createApiClient(config: ApiClientConfig) {
+  const { baseURL, refreshTokenURL = '/auth/refresh-token', onUnauthorized } = config;
+
+  let isRefreshing = false;
+  let refreshPromise: Promise<boolean> | null = null;
+
+  function buildURL(path: string, params?: RequestOptions['params']): string {
+    const url = new URL(path, baseURL);
+
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined) {
+          url.searchParams.set(key, String(value));
+        }
+      });
+    }
+
+    return url.toString();
+  }
+
+  async function refreshToken(): Promise<boolean> {
+    try {
+      const response = await fetch(buildURL(refreshTokenURL), {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async function handleUnauthorized(): Promise<boolean> {
+    // 이미 갱신 중이면 기존 Promise 재사용
+    if (isRefreshing && refreshPromise) {
+      return refreshPromise;
+    }
+
+    isRefreshing = true;
+    refreshPromise = refreshToken();
+
+    const success = await refreshPromise;
+
+    isRefreshing = false;
+    refreshPromise = null;
+
+    if (!success && onUnauthorized) {
+      onUnauthorized();
+    }
+
+    return success;
+  }
+
+  async function request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    options: RequestOptions = {},
+    isRetry = false
+  ): Promise<T> {
+    const { params, headers: customHeaders, ...restOptions } = options;
+
+    const url = buildURL(path, params);
+
+    const isFormData = body instanceof FormData;
+
+    const headers: HeadersInit = {
+      ...(body !== undefined && !isFormData && { 'Content-Type': 'application/json' }),
+      ...customHeaders,
+    };
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? (isFormData ? body : JSON.stringify(body)) : undefined,
+      credentials: 'include',
+      ...restOptions,
+    });
+
+    // 401 응답 시 토큰 갱신 후 재시도 (1회)
+    if (response.status === 401 && !isRetry) {
+      const refreshed = await handleUnauthorized();
+
+      if (refreshed) {
+        return request<T>(method, path, body, options, true);
+      }
+    }
+
+    // 204 No Content
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    // 에러 응답
+    if (!response.ok) {
+      throw await ApiError.fromResponse(response);
+    }
+
+    // JSON 응답 처리
+    const contentType = response.headers.get('content-type');
+    if (contentType?.includes('application/json')) {
+      const data = await response.json();
+      // 201 Created 시 Location 헤더 포함
+      if (response.status === 201) {
+        const location = response.headers.get('Location');
+        return { ...data, location } as T;
+      }
+      return data as T;
+    }
+
+    // 201 Created (JSON 아닌 경우)
+    if (response.status === 201) {
+      const location = response.headers.get('Location');
+      return { location } as T;
+    }
+
+    return undefined as T;
+  }
+
+  const client = {
+    /**
+     * GET 요청
+     */
+    get<T>(path: string, options?: RequestOptions): Promise<T> {
+      return request<T>('GET', path, undefined, options);
+    },
+
+    /**
+     * POST 요청
+     */
+    post<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+      return request<T>('POST', path, body, options);
+    },
+
+    /**
+     * PUT 요청
+     */
+    put<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+      return request<T>('PUT', path, body, options);
+    },
+
+    /**
+     * PATCH 요청
+     */
+    patch<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+      return request<T>('PATCH', path, body, options);
+    },
+
+    /**
+     * DELETE 요청
+     */
+    delete<T>(path: string, options?: RequestOptions): Promise<T> {
+      return request<T>('DELETE', path, undefined, options);
+    },
+
+    /**
+     * 파일 업로드 (진행률 콜백 지원)
+     * XHR 사용으로 업로드 진행률 추적 가능
+     */
+    upload<T>(path: string, file: File | File[], options: UploadOptions = {}): Promise<T> {
+      const { fieldName = 'file', onProgress, headers: customHeaders } = options;
+
+      const executeUpload = (isRetry = false): Promise<T> => {
+        return new Promise((resolve, reject) => {
+          const xhr = new XMLHttpRequest();
+          const url = buildURL(path);
+
+          const formData = new FormData();
+          if (Array.isArray(file)) {
+            file.forEach((f) => formData.append(fieldName, f));
+          } else {
+            formData.append(fieldName, file);
+          }
+
+          // 진행률 이벤트
+          if (onProgress) {
+            xhr.upload.addEventListener('progress', (event) => {
+              if (event.lengthComputable) {
+                const progress = Math.round((event.loaded / event.total) * 100);
+                onProgress(progress);
+              }
+            });
+          }
+
+          xhr.addEventListener('load', async () => {
+            // 401 시 토큰 갱신 후 재시도
+            if (xhr.status === 401 && !isRetry) {
+              const refreshed = await handleUnauthorized();
+              if (refreshed) {
+                resolve(executeUpload(true));
+                return;
+              }
+            }
+
+            if (xhr.status >= 200 && xhr.status < 300) {
+              try {
+                const responseData = JSON.parse(xhr.responseText);
+                if (xhr.status === 201) {
+                  const location = xhr.getResponseHeader('Location');
+                  resolve({ ...responseData, location } as T);
+                } else {
+                  resolve(responseData as T);
+                }
+              } catch {
+                reject(new ApiError(xhr.status, 'Failed to parse JSON response', 'PARSE_ERROR'));
+              }
+            } else {
+              let errorResponse;
+              try {
+                errorResponse = JSON.parse(xhr.responseText);
+              } catch {
+                // JSON 파싱 실패 시 무시
+              }
+              reject(
+                new ApiError(
+                  xhr.status,
+                  errorResponse?.message || xhr.statusText,
+                  errorResponse?.code,
+                  errorResponse
+                )
+              );
+            }
+          });
+
+          xhr.addEventListener('error', () => {
+            reject(new ApiError(0, 'Network error', 'NETWORK_ERROR'));
+          });
+
+          xhr.open('POST', url);
+          xhr.withCredentials = true;
+
+          if (customHeaders) {
+            Object.entries(customHeaders).forEach(([key, value]) => {
+              if (typeof value === 'string') {
+                xhr.setRequestHeader(key, value);
+              }
+            });
+          }
+
+          xhr.send(formData);
+        });
+      };
+
+      return executeUpload();
+    },
+  };
+
+  return client;
+}
+
+export type ApiClient = ReturnType<typeof createApiClient>;

--- a/packages/api/src/error.ts
+++ b/packages/api/src/error.ts
@@ -1,0 +1,90 @@
+import type { ErrorResponse } from './types';
+
+/**
+ * API 에러 클래스
+ */
+export class ApiError extends Error {
+  public readonly status: number;
+  public readonly code: string;
+  public readonly response?: ErrorResponse;
+
+  constructor(status: number, message: string, code?: string, response?: ErrorResponse) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code ?? `HTTP_${status}`;
+    this.response = response;
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+
+  /**
+   * 400 Bad Request 여부
+   */
+  get isBadRequest(): boolean {
+    return this.status === 400;
+  }
+
+  /**
+   * 401 Unauthorized 여부
+   */
+  get isUnauthorized(): boolean {
+    return this.status === 401;
+  }
+
+  /**
+   * 403 Forbidden 여부
+   */
+  get isForbidden(): boolean {
+    return this.status === 403;
+  }
+
+  /**
+   * 404 Not Found 여부
+   */
+  get isNotFound(): boolean {
+    return this.status === 404;
+  }
+
+  /**
+   * 409 Conflict 여부
+   */
+  get isConflict(): boolean {
+    return this.status === 409;
+  }
+
+  /**
+   * 5xx 서버 에러 여부
+   */
+  get isServerError(): boolean {
+    return this.status >= 500 && this.status < 600;
+  }
+
+  /**
+   * Response에서 ApiError 생성
+   */
+  static async fromResponse(response: Response): Promise<ApiError> {
+    let errorResponse: ErrorResponse | undefined;
+    let message = response.statusText || `HTTP Error ${response.status}`;
+    let code: string | undefined;
+
+    try {
+      const contentType = response.headers.get('content-type');
+      if (contentType?.includes('application/json')) {
+        errorResponse = (await response.json()) as ErrorResponse;
+        message = errorResponse.message || message;
+        code = errorResponse.code;
+      }
+    } catch {
+      // JSON 파싱 실패 시 기본 메시지 사용
+    }
+
+    return new ApiError(response.status, message, code, errorResponse);
+  }
+}
+
+/**
+ * ApiError 타입 가드
+ */
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,19 @@
+// Client
+export { createApiClient } from './client';
+export type { ApiClient } from './client';
+
+// Types
+export type {
+  DataResponse,
+  CreatedResponse,
+  PageData,
+  PageResponse,
+  ErrorResponse,
+  RequestOptions,
+  ApiClientConfig,
+  UploadOptions,
+  FileResponse,
+} from './types';
+
+// Error
+export { ApiError, isApiError } from './error';

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,0 +1,97 @@
+/**
+ * API 공통 응답 (성공)
+ * Backend DataResponseBody<T> 스펙
+ */
+export interface DataResponse<T> {
+  data: T;
+  status: number;
+  message?: string;
+  timestamp: string;
+}
+
+/**
+ * 생성 응답 (201 Created)
+ * Location 헤더 포함
+ */
+export interface CreatedResponse<T = number> {
+  data: T;
+  location: string | null;
+}
+
+/**
+ * 페이지네이션 데이터
+ */
+export interface PageData<T> {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+/**
+ * 페이지네이션 응답
+ */
+export interface PageResponse<T> {
+  data: PageData<T>;
+  status: number;
+  message?: string;
+  timestamp: string;
+}
+
+/**
+ * 에러 응답
+ * Backend ErrorResponseBody 스펙
+ */
+export interface ErrorResponse {
+  status: number;
+  message: string;
+  code: string;
+  error: string;
+  timestamp: string;
+}
+
+/**
+ * API 요청 옵션
+ */
+export interface RequestOptions extends Omit<RequestInit, 'method' | 'body'> {
+  params?: Record<string, string | number | boolean | undefined>;
+}
+
+/**
+ * API 클라이언트 설정
+ */
+export interface ApiClientConfig {
+  baseURL: string;
+  refreshTokenURL?: string;
+  onUnauthorized?: () => void;
+}
+
+/**
+ * 파일 업로드 옵션
+ */
+export interface UploadOptions extends Omit<RequestOptions, 'params'> {
+  /**
+   * FormData에서 파일 필드 이름 (기본값: 'file')
+   */
+  fieldName?: string;
+  /**
+   * 업로드 진행률 콜백 (0~100)
+   */
+  onProgress?: (progress: number) => void;
+}
+
+/**
+ * 파일 응답 (서버 스펙 기준)
+ */
+export interface FileResponse {
+  id: number;
+  url: string;
+  originalFileName: string;
+  contentType: string;
+  fileStatus: string;
+  createdAt: string;
+  createdBy: string;
+  updatedAt: string;
+  updatedBy: string;
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,12 @@ importers:
         specifier: 'catalog:'
         version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)
 
+  packages/api:
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/ui:
     dependencies:
       '@radix-ui/react-accordion':


### PR DESCRIPTION
## 개요
Backend API와 연동하기 위한 중간 레이어 역할을 하는 `@pf-dev/api` 패키지를 구현합니다.
공통 HTTP 클라이언트, 인증 토큰 관리, 에러 핸들링 등 API 호출에 필요한 기본 기능을 제공합니다.

## 주요 변경사항

### 1. HTTP 클라이언트 (`client.ts`)
- `createApiClient`: fetch 기반 HTTP 클라이언트 팩토리 함수
- GET, POST, PUT, PATCH, DELETE 메서드 지원
- 자동 JSON 직렬화/역직렬화
- `multipart/form-data` 파일 업로드 (XHR 기반 진행률 콜백)

### 2. 인증 처리
- httpOnly 쿠키 기반 인증 (`credentials: 'include'`)
- 401 응답 시 자동 토큰 갱신 후 요청 재시도
- 동시 요청 중 토큰 만료 시 단일 갱신 후 대기 요청 일괄 재시도
- 갱신 실패 시 `onUnauthorized` 콜백 호출

### 3. 에러 핸들링 (`error.ts`)
- `ApiError` 클래스: HTTP 상태 코드별 편의 getter 제공
- `isApiError` 타입 가드 함수
- Response에서 ApiError 생성 (`ApiError.fromResponse`)

### 4. 타입 정의 (`types.ts`)
- Swagger 스펙 기반 응답 타입 (`DataResponse<T>`, `ErrorResponse`)
- 페이지네이션 타입 (`PageData<T>`, `PageResponse<T>`)
- 요청/업로드 옵션 타입

## 파일 변경사항

### 추가
- `packages/api/src/client.ts` - HTTP 클라이언트 구현
- `packages/api/src/error.ts` - ApiError 클래스
- `packages/api/src/types.ts` - 공통 타입 정의
- `packages/api/src/index.ts` - Public exports
- `packages/api/package.json` - 패키지 설정
- `packages/api/tsconfig.json` - TypeScript 설정

## 테스트 항목
- [ ] GET/POST/PUT/PATCH/DELETE 요청 정상 동작
- [ ] 파일 업로드 및 진행률 콜백 동작
- [ ] 401 응답 시 토큰 갱신 후 재시도
- [ ] 동시 요청 시 단일 갱신 처리
- [ ] 타입 체크 통과 (`pnpm type-check`)
- [ ] 빌드 성공 (`pnpm build`)

## 사용 예시
```typescript
import { createApiClient, type DataResponse } from '@pf-dev/api';

const api = createApiClient({
  baseURL: import.meta.env.VITE_API_URL,
  onUnauthorized: () => {
    window.location.href = '/login';
  },
});

// GET 요청
const { data } = await api.get<DataResponse<User>>('/users/me');

// 파일 업로드
await api.upload('/files/upload', file, {
  onProgress: (percent) => console.log(`${percent}%`),
});
```

## 관련 이슈
Closes #3