### PR TITLE
ci: EPIC 브랜치 머지 시 이슈 자동 close 워크플로우

### DIFF
--- a/.github/workflows/close-issues-on-epic-merge.yml
+++ b/.github/workflows/close-issues-on-epic-merge.yml
@@ -1,0 +1,42 @@
+name: Close Issues on Epic Branch Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close-linked-issues:
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.base.ref, '-epic-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body || '';
+            const prTitle = context.payload.pull_request.title || '';
+
+            const pattern = /(?:close[sd]?|resolve[sd]?|fix(?:e[sd])?)\s+#(\d+)/gi;
+            const issueNumbers = new Set();
+
+            let match;
+            while ((match = pattern.exec(prBody)) !== null) {
+              issueNumbers.add(parseInt(match[1]));
+            }
+            pattern.lastIndex = 0;
+            while ((match = pattern.exec(prTitle)) !== null) {
+              issueNumbers.add(parseInt(match[1]));
+            }
+
+            for (const issueNumber of issueNumbers) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+            }


### PR DESCRIPTION
## 개요
EPIC 브랜치(`*-epic-*` 패턴)로 PR 머지 시 연결된 이슈를 자동으로 close하는 워크플로우 추가

## 배경
GitHub의 `Closes #X` 키워드는 기본 브랜치(main)로 머지할 때만 작동함.
EPIC 브랜치 전략 사용 시 sub-issue들이 자동으로 close되지 않는 문제 해결.

## 동작 방식
1. PR이 `-epic-` 패턴의 브랜치로 머지될 때 트리거
2. PR body/title에서 `Closes #X`, `Resolves #X`, `Fixes #X` 추출
3. GitHub API로 해당 이슈들 자동 close

## 테스트 항목
- [x] EPIC 브랜치로 머지 시 이슈 자동 close 확인