### PR TITLE
#155 - packages/ui 타입 export 누락 수정

### DIFF
--- a/.changeset/fix-ui-type-exports.md
+++ b/.changeset/fix-ui-type-exports.md
@@ -1,0 +1,8 @@
+---
+"@pf-dev/ui": patch
+---
+
+packages/ui 타입 export 누락 수정
+
+- Toast: UseToastReturn, ToastFunction 타입 export 추가
+- DataTable: 타입 제약 완화 및 가상 컬럼 지원 (key: keyof T | string)

--- a/packages/ui/src/molecules/Toast/index.ts
+++ b/packages/ui/src/molecules/Toast/index.ts
@@ -9,5 +9,6 @@ export {
 } from "./Toast";
 export { Toaster } from "./Toaster";
 export { useToast } from "./useToast";
+export type { UseToastReturn, ToastFunction } from "./useToast";
 export { toastVariants } from "./variants";
 export type { ToastProps, ToastData } from "./types";

--- a/packages/ui/src/molecules/Toast/useToast.ts
+++ b/packages/ui/src/molecules/Toast/useToast.ts
@@ -18,7 +18,7 @@ export interface ToastData {
 
 type ToastInput = Omit<ToastData, "id">;
 
-interface ToastFunction {
+export interface ToastFunction {
   (input: ToastInput | string): string;
   success: (input: ToastInput | string) => string;
   error: (input: ToastInput | string) => string;

--- a/packages/ui/src/organisms/DataTable/DataTable.tsx
+++ b/packages/ui/src/organisms/DataTable/DataTable.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from "../../atoms/Checkbox";
 import { Button } from "../../atoms/Button";
 
 export interface DataTableColumn<T> {
-  key: keyof T;
+  key: keyof T | string;
   header: string;
   sortable?: boolean;
   render?: (row: T, index: number) => React.ReactNode;
@@ -163,7 +163,7 @@ function DataTablePagination({
   );
 }
 
-function DataTableComponent<T extends Record<string, unknown>>({
+function DataTableComponent<T>({
   data,
   columns,
   selectable = false,
@@ -173,7 +173,7 @@ function DataTableComponent<T extends Record<string, unknown>>({
   className,
 }: DataTableProps<T>) {
   const [selectedRows, setSelectedRows] = useState<Set<number>>(new Set());
-  const [sortColumn, setSortColumn] = useState<keyof T | null>(null);
+  const [sortColumn, setSortColumn] = useState<keyof T | string | null>(null);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -206,7 +206,7 @@ function DataTableComponent<T extends Record<string, unknown>>({
     onSelectionChange?.(data.filter((_, i) => newSelected.has(i)));
   };
 
-  const handleSort = (columnKey: keyof T) => {
+  const handleSort = (columnKey: keyof T | string) => {
     if (sortColumn === columnKey) {
       setSortDirection(sortDirection === "asc" ? "desc" : "asc");
     } else {
@@ -217,8 +217,8 @@ function DataTableComponent<T extends Record<string, unknown>>({
 
   const sortedData = [...data].sort((a, b) => {
     if (!sortColumn) return 0;
-    const aVal = a[sortColumn];
-    const bVal = b[sortColumn];
+    const aVal = a[sortColumn as keyof T];
+    const bVal = b[sortColumn as keyof T];
     if (aVal === bVal) return 0;
     if (aVal == null) return 1;
     if (bVal == null) return -1;
@@ -310,7 +310,7 @@ function DataTableComponent<T extends Record<string, unknown>>({
                     >
                       {column.render
                         ? column.render(row, actualIndex)
-                        : String(row[column.key] ?? "")}
+                        : String(row[column.key as keyof T] ?? "")}
                     </td>
                   ))}
                 </tr>
@@ -333,8 +333,6 @@ function DataTableComponent<T extends Record<string, unknown>>({
   );
 }
 
-const DataTable = DataTableComponent as <T extends Record<string, unknown>>(
-  props: DataTableProps<T>
-) => React.ReactElement;
+const DataTable = DataTableComponent as <T>(props: DataTableProps<T>) => React.ReactElement;
 
 export { DataTable, DataTableBulkActionBar, DataTablePagination };


### PR DESCRIPTION
## 개요

`@pf-dev/ui` 패키지에서 TypeScript 타입이 제대로 export되지 않아 발생한 빌드 오류를 수정합니다. Toast 컴포넌트의 타입 누락과 DataTable의 타입 제약 문제를 해결했습니다.

## 주요 변경사항

### 1. Toast 타입 export 추가
- `UseToastReturn` 타입 export 추가
- `ToastFunction` 인터페이스를 export로 변경하여 외부에서 사용 가능하도록 수정

### 2. DataTable 타입 제약 완화
- 제네릭 타입 제약 `T extends Record<string, unknown>` 제거 - 인터페이스 타입 호환성 확보
- 가상 컬럼 지원: `key: keyof T | string` - "actions" 같은 테이블 전용 컬럼 허용
- 정렬 및 렌더링 로직에 적절한 타입 단언 추가

## 파일 변경사항

### 수정
- `packages/ui/src/molecules/Toast/index.ts` - UseToastReturn, ToastFunction 타입 export
- `packages/ui/src/molecules/Toast/useToast.ts` - ToastFunction 인터페이스 export 가능하도록 수정
- `packages/ui/src/organisms/DataTable/DataTable.tsx` - 타입 제약 완화 및 가상 컬럼 지원

## 테스트 항목
- [x] packages/ui 빌드 성공
- [x] demo 앱 빌드 성공 (\`pnpm --filter @pf-dev/demo-* build:staging\`)
- [x] 타입 체크 통과
- [x] Storybook에서 Toast 및 DataTable 동작 확인

## 관련 이슈
Closes #155