### PR TITLE
#216 - Staging 서버 자동 배포 CI/CD 워크플로우

### DIFF
--- a/.github/deploy-config.json
+++ b/.github/deploy-config.json
@@ -1,0 +1,10 @@
+{
+  "yongin-platform-app": {
+    "path": "/home/pluxity/docker/yonginplatform/front/",
+    "env": "staging"
+  },
+  "yongin-platform-admin": {
+    "path": "/home/pluxity/docker/yonginplatform/front/admin/",
+    "env": "staging"
+  }
+}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,115 @@
+name: Deploy to Staging
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  detect-changes:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_changes: ${{ steps.set-matrix.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Detect changed apps with Turborepo
+        id: set-matrix
+        run: |
+          # Get changed packages using turbo dry-run
+          CHANGED_PACKAGES=$(pnpm turbo build:staging --filter="...[origin/main^]" --dry-run=json 2>/dev/null | jq -r '.packages[]' | grep -v '//' | sort -u)
+
+          echo "Changed packages: $CHANGED_PACKAGES"
+
+          # Read deploy config
+          DEPLOY_CONFIG=$(cat .github/deploy-config.json)
+
+          # Build matrix from changed packages that exist in deploy config
+          MATRIX_ITEMS="[]"
+
+          for pkg in $CHANGED_PACKAGES; do
+            # Check if package exists in deploy config
+            PATH_VALUE=$(echo $DEPLOY_CONFIG | jq -r --arg pkg "$pkg" '.[$pkg].path // empty')
+            ENV_VALUE=$(echo $DEPLOY_CONFIG | jq -r --arg pkg "$pkg" '.[$pkg].env // empty')
+
+            if [ -n "$PATH_VALUE" ]; then
+              MATRIX_ITEMS=$(echo $MATRIX_ITEMS | jq --arg app "$pkg" --arg path "$PATH_VALUE" --arg env "$ENV_VALUE" '. + [{"app": $app, "path": $path, "env": $env}]')
+            fi
+          done
+
+          echo "Matrix: $MATRIX_ITEMS"
+
+          # Check if there are any changes to deploy
+          if [ "$MATRIX_ITEMS" = "[]" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "matrix={\"include\":$MATRIX_ITEMS}" >> $GITHUB_OUTPUT
+          fi
+
+  deploy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build ${{ matrix.app }}
+        run: pnpm turbo build:${{ matrix.env }} --filter=${{ matrix.app }}
+
+      - name: Deploy to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.PLX_DEV_DOMAIN }}
+          username: ${{ secrets.PLX_DEV_USER }}
+          password: ${{ secrets.PLX_DEV_PASSWORD }}
+          port: ${{ secrets.PLX_DEV_SSH_PORT }}
+          source: "apps/${{ matrix.app }}/dist/*"
+          target: ${{ matrix.path }}
+          strip_components: 3
+
+      - name: Deployment summary
+        run: |
+          echo "### Deployment Complete! :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| App | Path | Environment |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|------|-------------|" >> $GITHUB_STEP_SUMMARY
+          echo "| ${{ matrix.app }} | ${{ matrix.path }} | ${{ matrix.env }} |" >> $GITHUB_STEP_SUMMARY

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -1,0 +1,150 @@
+# CI/CD 가이드
+
+## 개요
+
+main 브랜치에 PR이 머지되면 GitHub Actions가 자동으로 스테이징 서버에 배포합니다.
+Turborepo를 활용하여 변경된 앱만 감지하고, 설정 파일 기반으로 동적 배포를 수행합니다.
+
+## 배포 흐름
+
+```
+PR 머지 → detect-changes → deploy-config.json 매칭 → 동적 matrix 생성 → 변경된 앱만 빌드/배포
+```
+
+## 현재 배포 설정
+
+| 앱 | 배포 경로 | 환경 |
+|----|-----------|------|
+| `yongin-platform-app` | `/home/pluxity/docker/yonginplatform/front/` | staging |
+| `yongin-platform-admin` | `/home/pluxity/docker/yonginplatform/front/admin/` | staging |
+
+## 새 앱 추가 방법
+
+### 1. deploy-config.json 수정
+
+`.github/deploy-config.json` 파일에 새 앱 정보를 추가합니다:
+
+```json
+{
+  "yongin-platform-app": {
+    "path": "/home/pluxity/docker/yonginplatform/front/",
+    "env": "staging"
+  },
+  "yongin-platform-admin": {
+    "path": "/home/pluxity/docker/yonginplatform/front/admin/",
+    "env": "staging"
+  },
+  "새-앱-이름": {
+    "path": "/home/pluxity/docker/새경로/",
+    "env": "staging"
+  }
+}
+```
+
+**필드 설명:**
+- `path`: 서버에서 빌드 파일이 배포될 절대 경로
+- `env`: 빌드 환경 (`staging`, `production` 등)
+
+### 2. 앱에 빌드 스크립트 확인
+
+해당 앱의 `package.json`에 빌드 스크립트가 있어야 합니다:
+
+```json
+{
+  "scripts": {
+    "build:staging": "vite build --mode staging"
+  }
+}
+```
+
+### 3. 환경 변수 파일 확인
+
+앱 디렉토리에 `.env.staging` 파일이 있어야 합니다:
+
+```env
+VITE_CONTEXT_PATH=/app-path
+VITE_API_BASE_PATH=/api
+```
+
+### 4. 서버에 배포 경로 생성
+
+스테이징 서버에서 배포 경로를 미리 생성합니다:
+
+```bash
+ssh user@dev.pluxity.com
+mkdir -p /home/pluxity/docker/새경로/
+```
+
+### 5. Nginx 설정 (필요시)
+
+새 앱에 대한 Nginx 설정이 필요한 경우 서버에서 설정합니다.
+
+## 워크플로우 파일
+
+`.github/workflows/deploy-staging.yml`
+
+**주요 단계:**
+1. **detect-changes**: Turborepo로 변경된 앱 감지
+2. **deploy**: 변경된 앱만 병렬로 빌드 & 배포
+
+## Secrets 설정
+
+Organization Secrets (pluxity)에 등록되어 있습니다:
+
+| Secret | 설명 |
+|--------|------|
+| `PLX_DEV_DOMAIN` | 서버 도메인 (예: `dev.pluxity.com`) |
+| `PLX_DEV_USER` | SSH 사용자명 |
+| `PLX_DEV_PASSWORD` | SSH 비밀번호 |
+| `PLX_DEV_SSH_PORT` | SSH 포트 |
+
+## 트러블슈팅
+
+### 배포가 트리거되지 않음
+
+1. PR이 main 브랜치로 머지되었는지 확인
+2. 변경된 파일이 `apps/` 디렉토리 내에 있는지 확인
+3. deploy-config.json에 해당 앱이 등록되어 있는지 확인
+
+### 빌드 실패
+
+1. 해당 앱에 `build:staging` 스크립트가 있는지 확인
+2. `.env.staging` 파일이 있는지 확인
+3. GitHub Actions 로그에서 에러 메시지 확인
+
+### SSH 배포 실패
+
+1. Organization Secrets가 올바르게 설정되어 있는지 확인
+2. 서버에서 배포 경로에 쓰기 권한이 있는지 확인
+3. 방화벽에서 SSH 포트가 열려 있는지 확인
+
+### 특정 앱만 수동 배포하고 싶을 때
+
+현재는 PR 머지 시 자동 배포만 지원합니다.
+수동 배포가 필요한 경우 로컬에서 직접 빌드 후 scp로 배포:
+
+```bash
+# 빌드
+pnpm turbo build:staging --filter=앱이름
+
+# 배포
+scp -r apps/앱이름/dist/* user@dev.pluxity.com:/배포/경로/
+```
+
+## 관련 파일
+
+```
+pf-frontend/
+├── .github/
+│   ├── deploy-config.json      # 앱별 배포 설정
+│   └── workflows/
+│       └── deploy-staging.yml  # 자동 배포 워크플로우
+├── apps/
+│   ├── yongin-platform-app/
+│   │   ├── .env.staging
+│   │   └── dist/               # 빌드 결과물
+│   └── yongin-platform-admin/
+│       ├── .env.staging
+│       └── dist/
+└── CI-CD.md                    # 이 문서
+```


### PR DESCRIPTION
## 개요
main 브랜치에 PR 머지 시 온프레미스 스테이징 서버에 자동 배포하는 GitHub Actions 워크플로우를 추가합니다.
Turborepo의 `--filter` 기능을 활용하여 변경된 앱만 감지하고, 설정 파일 기반으로 동적 배포를 수행합니다.

## 주요 변경사항

### 1. 설정 파일 기반 동적 배포
- `.github/deploy-config.json` 추가
- 앱별 배포 경로와 환경변수 설정
- 새 프로젝트 추가 시 설정 파일만 수정하면 자동 적용

### 2. GitHub Actions 워크플로우
- `.github/workflows/deploy-staging.yml` 추가
- PR 머지 시 자동 트리거
- Turborepo `--filter`로 변경된 앱만 감지
- 동적 matrix로 변경된 앱만 병렬 빌드/배포

### 3. CI/CD 가이드 문서
- `CI-CD.md` 추가
- 새 앱 추가 방법 설명
- 트러블슈팅 가이드 포함

## 파일 변경사항

### 추가
- `.github/deploy-config.json` - 앱별 배포 경로 설정
- `.github/workflows/deploy-staging.yml` - 자동 배포 워크플로우
- `CI-CD.md` - CI/CD 가이드 문서

## 워크플로우 흐름
```
PR 머지 → detect-changes (Turborepo로 변경된 앱 감지)
       → deploy-config.json과 매칭
       → 동적 matrix 생성
       → 변경된 앱만 빌드 & SSH 배포
```

## 테스트 항목
- [x] YAML 문법 검증 완료
- [x] JSON 설정 파일 문법 검증 완료
- [ ] PR 머지 후 워크플로우 실행 확인
- [ ] 변경된 앱만 빌드되는지 확인
- [ ] SSH 배포 경로 정상 동작 확인

## 관련 이슈
Closes #216