### PR TITLE
feat(app): CCTV 뷰어 컴포넌트 구현

### DIFF
--- a/apps/yongin-platform-app/src/components/CCTVViewer/CCTVCard.tsx
+++ b/apps/yongin-platform-app/src/components/CCTVViewer/CCTVCard.tsx
@@ -1,0 +1,76 @@
+import { useWHEPStream } from "@pf-dev/cctv";
+
+interface CCTVCardProps {
+  streamUrl: string;
+  name: string;
+  onClick?: () => void;
+}
+
+/**
+ * CCTV 단일 카드 컴포넌트
+ */
+export function CCTVCard({ streamUrl, name, onClick }: CCTVCardProps) {
+  const { videoRef, status, error, connect } = useWHEPStream(streamUrl);
+
+  return (
+    <div
+      className="relative bg-gray-900 rounded-lg overflow-hidden cursor-pointer h-full group"
+      onClick={onClick}
+    >
+      <video ref={videoRef} autoPlay playsInline muted className="w-full h-full object-contain" />
+
+      {status === "connecting" && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+          <div className="animate-spin w-8 h-8 border-2 border-white border-t-transparent rounded-full 4k:w-16 4k:h-16" />
+        </div>
+      )}
+
+      {status === "failed" && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center bg-gray-900/95 text-white">
+          {/* 경고 아이콘 */}
+          <div className="w-12 h-12 mb-3 bg-brand/20 rounded-full flex items-center justify-center 4k:w-24 4k:h-24 4k:mb-6">
+            <svg
+              className="w-6 h-6 text-brand 4k:w-12 4k:h-12"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          </div>
+
+          {/* 에러 메시지 */}
+          <p className="text-white font-medium mb-1 text-sm 4k:text-2xl">연결 실패</p>
+          {error && <p className="text-gray-400 text-xs mb-3 4k:text-lg">{error}</p>}
+
+          {/* 재연결 버튼 */}
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              connect();
+            }}
+            className="px-4 py-1.5 text-xs bg-brand rounded hover:bg-brand/80 transition-colors 4k:px-8 4k:py-3 4k:text-lg"
+          >
+            재연결
+          </button>
+        </div>
+      )}
+
+      {/* 하단 오버레이 */}
+      <div className="absolute bottom-0 left-0 right-0 flex items-center justify-between px-2 py-1.5 bg-gradient-to-t from-black/80 to-transparent 4k:px-4 4k:py-3">
+        {/* WebRTC 뱃지 */}
+        <span className="bg-purple-600 text-white text-[10px] font-semibold px-2 py-0.5 rounded 4k:text-base 4k:px-4 4k:py-1">
+          WebRTC
+        </span>
+
+        {/* CCTV 이름 */}
+        <span className="text-white text-xs font-medium 4k:text-lg">{name}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/yongin-platform-app/src/components/CCTVViewer/CCTVGrid.tsx
+++ b/apps/yongin-platform-app/src/components/CCTVViewer/CCTVGrid.tsx
@@ -1,0 +1,110 @@
+import { GridLayout, Widget } from "@pf-dev/ui";
+import { CCTVCard } from "./CCTVCard";
+import type { GridTemplate } from "./types";
+import type { CCTVPath } from "@/services/types";
+
+interface CCTVGridProps {
+  template: GridTemplate;
+  cctvs: CCTVPath[];
+  getStreamUrl: (name: string) => string;
+  onCardClick?: (index: number) => void;
+}
+
+/**
+ * CCTV 그리드 레이아웃 (드래그앤드롭 지원)
+ */
+export function CCTVGrid({ template, cctvs, getStreamUrl, onCardClick }: CCTVGridProps) {
+  // 1+5 레이아웃: GridLayout template 모드 사용
+  if (template.id === "1+5") {
+    const gridTemplate = {
+      id: "1+5",
+      name: "1+5",
+      columns: 3,
+      rows: 3,
+      cells: [
+        { id: "cell-1", colStart: 1, colSpan: 2, rowStart: 1, rowSpan: 2 }, // 큰 영역
+        { id: "cell-2", colStart: 3, colSpan: 1, rowStart: 1, rowSpan: 1 }, // 오른쪽 상단
+        { id: "cell-3", colStart: 3, colSpan: 1, rowStart: 2, rowSpan: 1 }, // 오른쪽 중간
+        { id: "cell-4", colStart: 1, colSpan: 1, rowStart: 3, rowSpan: 1 }, // 하단 왼쪽
+        { id: "cell-5", colStart: 2, colSpan: 1, rowStart: 3, rowSpan: 1 }, // 하단 중간
+        { id: "cell-6", colStart: 3, colSpan: 1, rowStart: 3, rowSpan: 1 }, // 하단 오른쪽
+      ],
+    };
+
+    return (
+      <GridLayout template={gridTemplate} gap={8} editable={true} className="h-full">
+        {Array.from({ length: 6 }, (_, i) => {
+          const cctv = cctvs[i];
+          return (
+            <Widget
+              key={`cell-${i + 1}`}
+              id={`cell-${i + 1}`}
+              border={false}
+              contentClassName="p-0 h-full"
+              className="h-full"
+            >
+              {cctv ? (
+                <CCTVCard
+                  streamUrl={getStreamUrl(cctv.name)}
+                  name={cctv.name}
+                  onClick={() => onCardClick?.(i)}
+                />
+              ) : (
+                <div className="flex items-center justify-center h-full bg-gray-800 rounded-lg text-gray-500 text-sm 4k:text-2xl">
+                  No Signal
+                </div>
+              )}
+            </Widget>
+          );
+        })}
+      </GridLayout>
+    );
+  }
+
+  // 일반 그리드 (1x1, 2x2, 3x3, 4x4) - template 모드로 변환
+  const cells = Array.from({ length: template.itemsPerPage }, (_, i) => ({
+    id: `cell-${i + 1}`,
+    colStart: (i % template.columns) + 1,
+    colSpan: 1,
+    rowStart: Math.floor(i / template.columns) + 1,
+    rowSpan: 1,
+  }));
+
+  const gridTemplate = {
+    id: template.id,
+    name: template.name,
+    columns: template.columns,
+    rows: template.rows,
+    cells,
+  };
+
+  return (
+    <GridLayout template={gridTemplate} gap={8} editable={true} className="h-full">
+      {Array.from({ length: template.itemsPerPage }, (_, i) => {
+        const cctv = cctvs[i];
+
+        return (
+          <Widget
+            key={`cell-${i + 1}`}
+            id={`cell-${i + 1}`}
+            border={false}
+            contentClassName="p-0 h-full"
+            className="h-full"
+          >
+            {cctv ? (
+              <CCTVCard
+                streamUrl={getStreamUrl(cctv.name)}
+                name={cctv.name}
+                onClick={() => onCardClick?.(i)}
+              />
+            ) : (
+              <div className="flex items-center justify-center h-full bg-gray-800 rounded-lg text-gray-500 text-sm 4k:text-2xl">
+                No Signal
+              </div>
+            )}
+          </Widget>
+        );
+      })}
+    </GridLayout>
+  );
+}

--- a/apps/yongin-platform-app/src/components/CCTVViewer/index.tsx
+++ b/apps/yongin-platform-app/src/components/CCTVViewer/index.tsx
@@ -1,0 +1,187 @@
+import { useState, useMemo } from "react";
+import { cn } from "@pf-dev/ui/utils";
+import { CCTVGrid } from "./CCTVGrid";
+import { GRID_TEMPLATES, type TemplateId } from "./types";
+import type { CCTVPath } from "@/services/types";
+
+interface CCTVViewerProps {
+  cctvs: CCTVPath[];
+  getStreamUrl: (name: string) => string;
+  onCardClick?: (cctvIndex: number) => void;
+}
+
+/**
+ * 템플릿 아이콘 (SVG)
+ */
+const TemplateIcons: Record<TemplateId, React.ReactNode> = {
+  "1x1": (
+    <svg className="w-4 h-4 4k:w-8 4k:h-8" viewBox="0 0 24 24" fill="currentColor">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+    </svg>
+  ),
+  "2x2": (
+    <svg className="w-4 h-4 4k:w-8 4k:h-8" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <rect x="3" y="3" width="8" height="8" rx="1" />
+      <rect x="13" y="3" width="8" height="8" rx="1" />
+      <rect x="3" y="13" width="8" height="8" rx="1" />
+      <rect x="13" y="13" width="8" height="8" rx="1" />
+    </svg>
+  ),
+  "1+5": (
+    <svg className="w-4 h-4 4k:w-8 4k:h-8" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <rect x="3" y="3" width="11" height="11" rx="1" strokeWidth="1.5" />
+      <rect x="16" y="3" width="5" height="5" rx="1" />
+      <rect x="16" y="9.5" width="5" height="5" rx="1" />
+      <rect x="3" y="16" width="5" height="5" rx="1" />
+      <rect x="9.5" y="16" width="5" height="5" rx="1" />
+      <rect x="16" y="16" width="5" height="5" rx="1" />
+    </svg>
+  ),
+  "3x3": (
+    <svg className="w-4 h-4 4k:w-8 4k:h-8" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <rect x="3" y="3" width="5" height="5" rx="1" />
+      <rect x="10" y="3" width="5" height="5" rx="1" />
+      <rect x="17" y="3" width="5" height="5" rx="1" />
+      <rect x="3" y="10" width="5" height="5" rx="1" />
+      <rect x="10" y="10" width="5" height="5" rx="1" />
+      <rect x="17" y="10" width="5" height="5" rx="1" />
+      <rect x="3" y="17" width="5" height="5" rx="1" />
+      <rect x="10" y="17" width="5" height="5" rx="1" />
+      <rect x="17" y="17" width="5" height="5" rx="1" />
+    </svg>
+  ),
+  "4x4": (
+    <svg className="w-4 h-4 4k:w-8 4k:h-8" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <line x1="3" y1="8" x2="21" y2="8" />
+      <line x1="3" y1="13" x2="21" y2="13" />
+      <line x1="3" y1="18" x2="21" y2="18" />
+      <line x1="8" y1="3" x2="8" y2="21" />
+      <line x1="13" y1="3" x2="13" y2="21" />
+      <line x1="18" y1="3" x2="18" y2="21" />
+      <rect x="3" y="3" width="18" height="18" rx="1" />
+    </svg>
+  ),
+};
+
+// 템플릿 순서: 1, 4, 1+5, 9, 16
+const TEMPLATE_ORDER: TemplateId[] = ["1x1", "2x2", "1+5", "3x3", "4x4"];
+
+/**
+ * CCTV 뷰어 메인 컴포넌트
+ */
+export function CCTVViewer({ cctvs, getStreamUrl, onCardClick }: CCTVViewerProps) {
+  const [selectedTemplate, setSelectedTemplate] = useState<TemplateId>("4x4");
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const template = GRID_TEMPLATES[selectedTemplate];
+  const totalPages = Math.ceil(cctvs.length / template.itemsPerPage);
+
+  // 현재 페이지 CCTV 목록
+  const currentCCTVs = useMemo(() => {
+    const start = currentPage * template.itemsPerPage;
+    return cctvs.slice(start, start + template.itemsPerPage);
+  }, [cctvs, currentPage, template.itemsPerPage]);
+
+  // 템플릿 변경 시 페이지 리셋
+  const handleTemplateChange = (templateId: TemplateId) => {
+    setSelectedTemplate(templateId);
+    setCurrentPage(0);
+  };
+
+  // 페이지 변경
+  const handlePageChange = (direction: "prev" | "next") => {
+    setCurrentPage((prev) => {
+      if (direction === "prev") {
+        return Math.max(0, prev - 1);
+      }
+      return Math.min(totalPages - 1, prev + 1);
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* 상단 툴바 */}
+      <div className="flex items-center justify-between px-4 py-2 bg-primary-100/70 border-b border-primary-100 4k:px-8 4k:py-4">
+        {/* 템플릿 선택 */}
+        <div className="flex items-center gap-1 bg-white/80 rounded-lg p-1 4k:gap-2 4k:p-2">
+          {TEMPLATE_ORDER.map((id) => {
+            const tmpl = GRID_TEMPLATES[id];
+            return (
+              <button
+                key={id}
+                onClick={() => handleTemplateChange(id)}
+                className={cn(
+                  "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm transition-colors 4k:px-6 4k:py-3 4k:text-xl 4k:gap-3",
+                  selectedTemplate === id
+                    ? "bg-brand text-white shadow-sm"
+                    : "text-primary-700 hover:text-primary-900 hover:bg-primary-50"
+                )}
+                title={tmpl.name}
+              >
+                {TemplateIcons[id]}
+                <span className="hidden sm:inline">{tmpl.name}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* 페이지네이션 */}
+        <div className="flex items-center gap-3 text-primary-800 4k:gap-6">
+          <button
+            onClick={() => handlePageChange("prev")}
+            disabled={currentPage === 0}
+            className="p-1.5 rounded-lg hover:bg-white/60 disabled:opacity-30 disabled:cursor-not-allowed transition-colors 4k:p-3"
+            aria-label="이전 페이지"
+          >
+            <svg
+              className="w-5 h-5 4k:w-10 4k:h-10"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+
+          <span className="text-sm font-medium min-w-[60px] text-center 4k:text-2xl 4k:min-w-[120px]">
+            {currentPage + 1} / {totalPages || 1}
+          </span>
+
+          <button
+            onClick={() => handlePageChange("next")}
+            disabled={currentPage >= totalPages - 1}
+            className="p-1.5 rounded-lg hover:bg-white/60 disabled:opacity-30 disabled:cursor-not-allowed transition-colors 4k:p-3"
+            aria-label="다음 페이지"
+          >
+            <svg
+              className="w-5 h-5 4k:w-10 4k:h-10"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* CCTV 그리드 */}
+      <div className="flex-1 overflow-hidden p-4 bg-primary-50/30 4k:p-8">
+        <CCTVGrid
+          template={template}
+          cctvs={currentCCTVs}
+          getStreamUrl={getStreamUrl}
+          onCardClick={(index) => {
+            const globalIndex = currentPage * template.itemsPerPage + index;
+            onCardClick?.(globalIndex);
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/yongin-platform-app/src/components/CCTVViewer/types.ts
+++ b/apps/yongin-platform-app/src/components/CCTVViewer/types.ts
@@ -1,0 +1,47 @@
+export type TemplateId = "1x1" | "2x2" | "3x3" | "4x4" | "1+5";
+
+export interface GridTemplate {
+  id: TemplateId;
+  name: string;
+  columns: number;
+  rows: number;
+  itemsPerPage: number;
+}
+
+export const GRID_TEMPLATES: Record<TemplateId, GridTemplate> = {
+  "1x1": {
+    id: "1x1",
+    name: "1개",
+    columns: 1,
+    rows: 1,
+    itemsPerPage: 1,
+  },
+  "2x2": {
+    id: "2x2",
+    name: "4개",
+    columns: 2,
+    rows: 2,
+    itemsPerPage: 4,
+  },
+  "3x3": {
+    id: "3x3",
+    name: "9개",
+    columns: 3,
+    rows: 3,
+    itemsPerPage: 9,
+  },
+  "4x4": {
+    id: "4x4",
+    name: "16개",
+    columns: 4,
+    rows: 4,
+    itemsPerPage: 16,
+  },
+  "1+5": {
+    id: "1+5",
+    name: "1+5",
+    columns: 3,
+    rows: 3,
+    itemsPerPage: 6,
+  },
+};

--- a/apps/yongin-platform-app/src/components/CenterContainer/views/CCTVView.tsx
+++ b/apps/yongin-platform-app/src/components/CenterContainer/views/CCTVView.tsx
@@ -1,14 +1,42 @@
+import { Skeleton } from "@pf-dev/ui";
+import { useCCTVStreams } from "@/hooks";
+import { CCTVViewer } from "@/components/CCTVViewer";
+
 /**
  * CCTV 뷰 컴포넌트
- * @see https://github.com/pluxity/pf-frontend/issues/170
+ * @see https://github.com/pluxity/pf-frontend/issues/252
  */
 export function CCTVView() {
-  return (
-    <div className="flex items-center justify-center h-full bg-gray-100">
-      <div className="text-center">
-        <h2 className="text-2xl font-bold text-gray-700 4k:text-5xl">CCTV</h2>
-        <p className="mt-2 text-gray-500 4k:text-2xl">#170 - CCTV 컴포넌트가 여기에 렌더링됩니다</p>
+  const { paths, isLoading, isError, getWHEPUrl } = useCCTVStreams();
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col h-full bg-primary-50/30 p-4 gap-4 4k:p-8 4k:gap-8">
+        {/* 툴바 스켈레톤 */}
+        <Skeleton className="h-12 w-full 4k:h-24" />
+
+        {/* 그리드 스켈레톤 (4x4) */}
+        <div className="flex-1 grid grid-cols-4 grid-rows-4 gap-2 4k:gap-4">
+          {Array.from({ length: 16 }).map((_, i) => (
+            <Skeleton key={i} className="w-full h-full" />
+          ))}
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
+
+  if (isError || paths.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full bg-primary-50/30">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold text-primary-800 4k:text-5xl">CCTV</h2>
+          <p className="mt-2 text-primary-700 4k:text-2xl">
+            {isError ? "스트림을 불러올 수 없습니다" : "등록된 CCTV가 없습니다"}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return <CCTVViewer cctvs={paths} getStreamUrl={getWHEPUrl} />;
 }

--- a/apps/yongin-platform-app/src/hooks/index.ts
+++ b/apps/yongin-platform-app/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useAnnouncement } from "./useAnnouncement";
+export { useCCTVStreams } from "./useCCTVStreams";

--- a/apps/yongin-platform-app/src/hooks/useCCTVStreams.ts
+++ b/apps/yongin-platform-app/src/hooks/useCCTVStreams.ts
@@ -1,0 +1,18 @@
+import useSWR from "swr";
+import { cctvService } from "@/services";
+
+const PATHS_KEY = "/media/paths";
+
+export function useCCTVStreams() {
+  const { data, error, isLoading } = useSWR(PATHS_KEY, () => cctvService.getPaths());
+
+  return {
+    paths: data?.items ?? [],
+    itemCount: data?.itemCount ?? 0,
+    isLoading,
+    isError: !!error,
+    error,
+    getHLSUrl: cctvService.getHLSUrl,
+    getWHEPUrl: cctvService.getWHEPUrl,
+  };
+}

--- a/apps/yongin-platform-app/src/main.tsx
+++ b/apps/yongin-platform-app/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { configureApi } from "@pf-dev/api";
+import { useWHEPStore } from "@pf-dev/cctv";
 
 import { App } from "./App";
 import "./styles/globals.css";
@@ -11,6 +12,9 @@ const contextPath = import.meta.env.VITE_CONTEXT_PATH || "";
 configureApi({
   baseURL: "/api",
 });
+
+// WHEP 초기화
+useWHEPStore.getState().initialize();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/apps/yongin-platform-app/src/services/cctv.service.ts
+++ b/apps/yongin-platform-app/src/services/cctv.service.ts
@@ -1,0 +1,23 @@
+import type { CCTVPathsResponse, CCTVStreamsResponse } from "./types";
+
+const MEDIA_SERVER_URL = import.meta.env.VITE_MEDIA_SERVER_URL ?? "";
+
+export const cctvService = {
+  /** v3 - 기본 사용 */
+  getPaths: async (): Promise<CCTVPathsResponse> => {
+    const res = await fetch(`${MEDIA_SERVER_URL}/api/v3/paths/list`);
+    if (!res.ok) throw new Error(`Failed to fetch paths: ${res.status}`);
+    return res.json() as Promise<CCTVPathsResponse>;
+  },
+
+  /** v1 - 레거시 (추후 사용) */
+  getStreams: async (): Promise<CCTVStreamsResponse> => {
+    const res = await fetch(`${MEDIA_SERVER_URL}/api/v1/streams`);
+    if (!res.ok) throw new Error(`Failed to fetch streams: ${res.status}`);
+    return res.json() as Promise<CCTVStreamsResponse>;
+  },
+
+  getHLSUrl: (streamName: string): string => `${MEDIA_SERVER_URL}/${streamName}/index.m3u8`,
+
+  getWHEPUrl: (streamName: string): string => `${MEDIA_SERVER_URL}/webrtc/${streamName}/whep`,
+};

--- a/apps/yongin-platform-app/src/services/index.ts
+++ b/apps/yongin-platform-app/src/services/index.ts
@@ -1,2 +1,3 @@
 export * from "./announcement.service";
+export * from "./cctv.service";
 export * from "./types";

--- a/apps/yongin-platform-app/src/services/types/cctv.ts
+++ b/apps/yongin-platform-app/src/services/types/cctv.ts
@@ -1,0 +1,43 @@
+/** v3 API - /api/v3/paths/list */
+export interface CCTVPath {
+  name: string;
+  confName: string;
+  source: {
+    type: string;
+    id: string;
+  };
+  ready: boolean;
+  readyTime: string | null;
+  tracks: string[];
+  bytesReceived: number;
+  bytesSent: number;
+  readers: unknown[];
+  ptz: boolean;
+  ptzType: string;
+}
+
+export interface CCTVPathsResponse {
+  itemCount: number;
+  pageCount: number;
+  items: CCTVPath[];
+}
+
+/** v1 API - /api/v1/streams (레거시) */
+export interface CCTVStream {
+  id: string;
+  name: string;
+  source: string;
+  source_on_demand: boolean;
+  rtsp_transport: string;
+  source_type: "config" | "database";
+  runtime_info?: {
+    is_active: boolean;
+    codec: string;
+    subscriber_count: number;
+  };
+}
+
+export interface CCTVStreamsResponse {
+  count: number;
+  streams: CCTVStream[];
+}

--- a/apps/yongin-platform-app/src/services/types/index.ts
+++ b/apps/yongin-platform-app/src/services/types/index.ts
@@ -1,1 +1,2 @@
 export * from "./announcement";
+export * from "./cctv";


### PR DESCRIPTION
## 개요
용인 플랫폼 앱에 CCTV 실시간 스트리밍 뷰어 컴포넌트를 구현합니다.

## 변경사항

### 컴포넌트
- **CCTVViewer**: 메인 뷰어 컴포넌트
  - 템플릿 선택 (1x1, 2x2, 3x3, 4x4, 1+5)
  - 페이지네이션 (이전/다음)
  - Primary 테마 색상 적용
- **CCTVGrid**: GridLayout 기반 반응형 그리드
  - 드래그앤드롭 지원 (template mode)
  - Widget 래퍼로 일관된 레이아웃
  - 5가지 템플릿 지원
- **CCTVCard**: 개별 CCTV 카드
  - WHEP 프로토콜 기반 WebRTC 스트리밍
  - 연결 상태 표시 (connecting, failed)
  - 재연결 기능
  - `object-contain`으로 날짜/시간 정보 보존

### 서비스 & 훅
- **cctvService**: MediaMTX v3 API 연동
  - `getPaths()`: CCTV 경로 목록 조회
  - `getWHEPUrl()`: WHEP URL 생성
- **useCCTVStreams**: CCTV 데이터 관리 훅
  - 로딩/에러 상태 관리
  - WHEP URL 생성 함수 제공

### 스타일링
- Primary 테마 색상 적용 (`bg-primary-50/100/800`)
- 4K 해상도 대응 반응형 디자인
- GridLayout editable 모드 지원

## 스크린샷
[추후 추가 예정]

## 테스트 체크리스트
- [x] 5가지 템플릿 전환 동작
- [x] 페이지네이션 동작
- [x] WHEP 스트리밍 재생
- [x] 연결 실패 시 재연결 버튼
- [x] 로딩 스켈레톤 UI
- [x] 에러 상태 처리
- [x] 날짜/시간 정보 표시 (object-contain)
- [x] 드래그앤드롭 위치 변경 (데스크톱 모드)
- [x] 4K 해상도 확인

## 기술 스택
- **스트리밍**: `@pf-dev/cctv` (WHEP)
- **레이아웃**: `@pf-dev/ui` (GridLayout, Widget)
- **상태관리**: React hooks (useCCTVStreams)
- **API**: MediaMTX v3 `/api/v3/paths/list`

## 체크리스트
- [x] 타입 체크 통과
- [x] 린트 통과 (pre-commit hook)
- [x] Primary 테마 색상 사용
- [x] 4K 반응형 대응
- [ ] Storybook 문서 (선택)

## 관련 이슈
Refs #252

## 추가 작업 예정
- 레이아웃 확정 후 `object-contain` vs `object-cover` 재검토
- 드래그앤드롭 동작 터치 모드 지원 검토