### PR TITLE
Carousel 네비게이션 화살표 버튼 개선

### DIFF
--- a/.changeset/carousel-arrow-improvements.md
+++ b/.changeset/carousel-arrow-improvements.md
@@ -1,0 +1,9 @@
+---
+"@pf-dev/ui": patch
+---
+
+Carousel 네비게이션 화살표 버튼 개선
+
+- `arrowVariant` prop 추가 (`"default"` | `"ghost"`) - ghost 모드에서 배경/그림자 없이 아이콘만 표시
+- `arrowClassName` prop 추가 - 화살표 버튼에 커스텀 클래스 적용 (위치 조정 등)
+- focus 스타일을 `focus-visible`로 변경 - 마우스 클릭 시 포커스 링 미표시, 키보드 네비게이션에서만 표시

--- a/packages/ui/src/molecules/Carousel/Carousel.stories.tsx
+++ b/packages/ui/src/molecules/Carousel/Carousel.stories.tsx
@@ -47,6 +47,15 @@ const meta: Meta<typeof Carousel> = {
       control: "number",
       description: "전환 애니메이션 시간 (ms)",
     },
+    arrowVariant: {
+      control: "select",
+      options: ["default", "ghost"],
+      description: "화살표 버튼 스타일 변형",
+    },
+    arrowClassName: {
+      control: "text",
+      description: "화살표 버튼 커스텀 클래스",
+    },
   },
 };
 
@@ -259,6 +268,42 @@ export const Controlled: Story = {
       </div>
     );
   },
+};
+
+export const GhostArrows: Story = {
+  name: "화살표 Ghost 모드",
+  render: () => (
+    <div className="w-[600px] h-[300px]">
+      <Carousel arrowVariant="ghost">
+        {slides.map((slide, index) => (
+          <div
+            key={index}
+            className={`${slide.bg} w-full h-[300px] flex items-center justify-center text-white text-2xl font-bold`}
+          >
+            {slide.text}
+          </div>
+        ))}
+      </Carousel>
+    </div>
+  ),
+};
+
+export const CustomArrowPosition: Story = {
+  name: "화살표 위치 커스터마이징",
+  render: () => (
+    <div className="w-[600px] h-[300px]">
+      <Carousel arrowVariant="ghost" arrowClassName="!top-4 !translate-y-0">
+        {slides.map((slide, index) => (
+          <div
+            key={index}
+            className={`${slide.bg} w-full h-[300px] flex items-center justify-center text-white text-2xl font-bold`}
+          >
+            {slide.text}
+          </div>
+        ))}
+      </Carousel>
+    </div>
+  ),
 };
 
 export const AllTransitions: Story = {

--- a/packages/ui/src/molecules/Carousel/Carousel.tsx
+++ b/packages/ui/src/molecules/Carousel/Carousel.tsx
@@ -9,6 +9,7 @@ import {
   type KeyboardEvent,
 } from "react";
 import { cn } from "../../utils";
+import { Button } from "../../atoms/Button";
 import { ChevronLeft, ChevronRight } from "../../atoms/Icon";
 import type { CarouselProps, CarouselContextValue } from "./types";
 import { CarouselContext } from "./CarouselContext";
@@ -30,6 +31,8 @@ function Carousel({
   activeIndex: controlledIndex,
   onChange,
   transitionDuration = 300,
+  arrowVariant = "default",
+  arrowClassName,
   className,
   ref,
   ...props
@@ -161,6 +164,30 @@ function Carousel({
     return {};
   }, [activeIndex, transition, transitionDuration]);
 
+  const arrowButtonVariant = arrowVariant === "ghost" ? "ghost" : "secondary";
+
+  const renderArrowButton = (
+    direction: "prev" | "next",
+    onClick: () => void,
+    disabled: boolean
+  ) => (
+    <Button
+      variant={arrowButtonVariant}
+      size="icon"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "absolute top-1/2 -translate-y-1/2 z-10 rounded-full [&_svg]:size-5",
+        direction === "prev" ? "left-2" : "right-2",
+        arrowVariant === "default" && "bg-white/80 shadow-md hover:bg-white",
+        arrowClassName
+      )}
+      aria-label={direction === "prev" ? "Previous slide" : "Next slide"}
+    >
+      {direction === "prev" ? <ChevronLeft size="xl" /> : <ChevronRight size="xl" />}
+    </Button>
+  );
+
   return (
     <CarouselContext.Provider value={contextValue}>
       <div
@@ -199,38 +226,8 @@ function Carousel({
         {/* Navigation Arrows */}
         {showArrows && totalSlides > 1 && (
           <>
-            <button
-              type="button"
-              onClick={goPrev}
-              disabled={!loop && activeIndex === 0}
-              className={cn(
-                "absolute left-2 top-1/2 -translate-y-1/2 z-10",
-                "w-10 h-10 rounded-full bg-white/80 shadow-md",
-                "flex items-center justify-center",
-                "hover:bg-white transition-colors",
-                "disabled:opacity-50 disabled:cursor-not-allowed",
-                "focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2"
-              )}
-              aria-label="Previous slide"
-            >
-              <ChevronLeft size="lg" />
-            </button>
-            <button
-              type="button"
-              onClick={goNext}
-              disabled={!loop && activeIndex === totalSlides - 1}
-              className={cn(
-                "absolute right-2 top-1/2 -translate-y-1/2 z-10",
-                "w-10 h-10 rounded-full bg-white/80 shadow-md",
-                "flex items-center justify-center",
-                "hover:bg-white transition-colors",
-                "disabled:opacity-50 disabled:cursor-not-allowed",
-                "focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2"
-              )}
-              aria-label="Next slide"
-            >
-              <ChevronRight size="lg" />
-            </button>
+            {renderArrowButton("prev", goPrev, !loop && activeIndex === 0)}
+            {renderArrowButton("next", goNext, !loop && activeIndex === totalSlides - 1)}
           </>
         )}
 
@@ -244,7 +241,7 @@ function Carousel({
                 onClick={() => goTo(index)}
                 className={cn(
                   "w-2 h-2 rounded-full transition-all",
-                  "focus:outline-none focus:ring-2 focus:ring-brand focus:ring-offset-2",
+                  "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2",
                   index === activeIndex ? "bg-brand w-6" : "bg-gray-300 hover:bg-gray-400"
                 )}
                 aria-label={`Go to slide ${index + 1}`}

--- a/packages/ui/src/molecules/Carousel/index.ts
+++ b/packages/ui/src/molecules/Carousel/index.ts
@@ -1,3 +1,8 @@
 export { Carousel } from "./Carousel";
 export { useCarousel } from "./useCarousel";
-export type { CarouselProps, CarouselTransition, CarouselContextValue } from "./types";
+export type {
+  CarouselProps,
+  CarouselTransition,
+  CarouselArrowVariant,
+  CarouselContextValue,
+} from "./types";

--- a/packages/ui/src/molecules/Carousel/types.ts
+++ b/packages/ui/src/molecules/Carousel/types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode, ComponentPropsWithoutRef } from "react";
 
 export type CarouselTransition = "slide" | "fade" | "none";
+export type CarouselArrowVariant = "default" | "ghost";
 
 export interface CarouselProps extends Omit<ComponentPropsWithoutRef<"div">, "onChange"> {
   children: ReactNode[];
@@ -15,6 +16,8 @@ export interface CarouselProps extends Omit<ComponentPropsWithoutRef<"div">, "on
   activeIndex?: number;
   onChange?: (index: number) => void;
   transitionDuration?: number;
+  arrowVariant?: CarouselArrowVariant;
+  arrowClassName?: string;
 }
 
 export interface CarouselContextValue {


### PR DESCRIPTION
## Summary
- Carousel 화살표 버튼에 `arrowVariant` prop 추가 (`default` | `ghost`)
- `arrowClassName` prop 추가로 화살표 위치 커스터마이징 가능
- 네이티브 `<button>` → `Button` 아톰으로 전환하여 디자인 시스템 일관성 확보
- `focus` → `focus-visible` 변경 (마우스 클릭 시 포커스 링 미표시)
- 화살표 버튼 중복 코드 `renderArrowButton`으로 리팩토링

## Changes
- `packages/ui/src/molecules/Carousel/types.ts` - `CarouselArrowVariant`, `arrowVariant`, `arrowClassName` 추가
- `packages/ui/src/molecules/Carousel/Carousel.tsx` - Button 아톰 적용, renderArrowButton 추출, focus-visible 변경
- `packages/ui/src/molecules/Carousel/index.ts` - `CarouselArrowVariant` 타입 export
- `packages/ui/src/molecules/Carousel/Carousel.stories.tsx` - GhostArrows, CustomArrowPosition 스토리 추가
- `.changeset/carousel-arrow-improvements.md` - patch changeset

## Test plan
- [x] Storybook에서 기본 Carousel 화살표 동작 확인
- [x] Ghost 모드 화살표 확인 (배경/그림자 없음)
- [x] arrowClassName으로 위치 오버라이드 확인
- [x] 마우스 클릭 시 포커스 링 미표시 확인
- [x] 키보드 Tab → Enter 시 포커스 링 표시 확인
- [x] 인디케이터 focus-visible 동작 확인

Closes #277