### PR TITLE
#345 - feat(cctv): WHEP ICE Trickle 지원 추가

### DIFF
--- a/.changeset/whep-ice-trickle.md
+++ b/.changeset/whep-ice-trickle.md
@@ -1,0 +1,10 @@
+---
+"@pf-dev/cctv": minor
+---
+
+WHEP ICE Trickle 지원 추가
+
+- WHEP 표준의 ICE Trickle 확장(RFC 8840) 구현
+- SDP Offer에서 ICE credentials 파싱 및 SDP Fragment 생성
+- Session URL(Location 헤더) 기반 PATCH로 ICE candidate 전달
+- ICE Trickle 미지원 서버에서도 기존과 동일하게 동작 (하위호환)

--- a/packages/cctv/src/whep/client.ts
+++ b/packages/cctv/src/whep/client.ts
@@ -1,17 +1,99 @@
 import type { WHEPNegotiationResult } from "./types";
 
+interface OfferData {
+  iceUfrag: string;
+  icePwd: string;
+  medias: string[];
+}
+
+function parseOffer(sdp: string): OfferData {
+  const result: OfferData = { iceUfrag: "", icePwd: "", medias: [] };
+
+  for (const line of sdp.split("\r\n")) {
+    if (line.startsWith("m=")) {
+      result.medias.push(line.slice("m=".length));
+    } else if (result.iceUfrag === "" && line.startsWith("a=ice-ufrag:")) {
+      result.iceUfrag = line.slice("a=ice-ufrag:".length);
+    } else if (result.icePwd === "" && line.startsWith("a=ice-pwd:")) {
+      result.icePwd = line.slice("a=ice-pwd:".length);
+    }
+  }
+
+  return result;
+}
+
+function generateSdpFragment(offerData: OfferData, candidates: RTCIceCandidate[]): string {
+  const candidatesByMedia: Record<number, RTCIceCandidate[]> = {};
+  for (const candidate of candidates) {
+    const mid = candidate.sdpMLineIndex ?? 0;
+    if (candidatesByMedia[mid] === undefined) {
+      candidatesByMedia[mid] = [];
+    }
+    candidatesByMedia[mid]!.push(candidate);
+  }
+
+  let frag = `a=ice-ufrag:${offerData.iceUfrag}\r\n` + `a=ice-pwd:${offerData.icePwd}\r\n`;
+
+  let mid = 0;
+  for (const media of offerData.medias) {
+    if (candidatesByMedia[mid] !== undefined) {
+      frag += `m=${media}\r\n` + `a=mid:${mid}\r\n`;
+
+      for (const candidate of candidatesByMedia[mid]!) {
+        frag += `a=${candidate.candidate}\r\n`;
+      }
+    }
+    mid++;
+  }
+
+  return frag;
+}
+
+function sendLocalCandidates(
+  sessionUrl: string,
+  offerData: OfferData,
+  candidates: RTCIceCandidate[]
+): void {
+  fetch(sessionUrl, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/trickle-ice-sdpfrag",
+      "If-Match": "*",
+    },
+    body: generateSdpFragment(offerData, candidates),
+  }).catch(() => {
+    // PATCH 실패는 무시 (연결 자체는 ICE trickle 없이도 동작 가능)
+  });
+}
+
 export async function performWhepNegotiation(
   pc: RTCPeerConnection,
   streamUrl: string,
   signal?: AbortSignal
 ): Promise<WHEPNegotiationResult> {
   const offer = await pc.createOffer();
+  const offerSdp = offer.sdp || "";
+  const offerData = parseOffer(offerSdp);
+
+  let sessionUrl: string | null = null;
+  let queuedCandidates: RTCIceCandidate[] = [];
+
+  pc.onicecandidate = (evt) => {
+    if (evt.candidate !== null) {
+      if (sessionUrl === null) {
+        queuedCandidates.push(evt.candidate);
+      } else {
+        sendLocalCandidates(sessionUrl, offerData, [evt.candidate]);
+      }
+    }
+  };
+
   await pc.setLocalDescription(offer);
 
   const response = await fetch(streamUrl, {
     method: "POST",
     headers: { "Content-Type": "application/sdp" },
-    body: offer.sdp || "",
+    body: offerSdp,
     signal,
   });
 
@@ -19,10 +101,20 @@ export async function performWhepNegotiation(
     throw new Error(`WHEP negotiation failed: ${response.status} ${response.statusText}`);
   }
 
+  const locationHeader = response.headers.get("location");
+  if (locationHeader) {
+    sessionUrl = new URL(locationHeader, streamUrl).toString();
+  }
+
   const answerSdp = await response.text();
   await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
 
-  return { answerSdp };
+  if (sessionUrl !== null && queuedCandidates.length > 0) {
+    sendLocalCandidates(sessionUrl, offerData, queuedCandidates);
+    queuedCandidates = [];
+  }
+
+  return { answerSdp, sessionUrl };
 }
 
 export function createReceiverPeerConnection(

--- a/packages/cctv/src/whep/types.ts
+++ b/packages/cctv/src/whep/types.ts
@@ -2,6 +2,7 @@ import type { BaseStreamConfig, IceServerConfig, StreamStatus, CCTVInfo } from "
 
 export interface WHEPNegotiationResult {
   answerSdp: string;
+  sessionUrl: string | null;
 }
 
 export interface WHEPConfig extends BaseStreamConfig {


### PR DESCRIPTION
## Summary
- WHEP 표준의 ICE Trickle 확장(RFC 8840) 구현
- SDP Offer에서 ICE credentials 파싱 및 SDP Fragment 생성
- Session URL(Location 헤더) 기반 PATCH로 ICE candidate 전달
- ICE Trickle 미지원 서버에서도 기존과 동일하게 동작 (하위호환)

## Changes
- `packages/cctv/src/whep/types.ts` — `WHEPNegotiationResult`에 `sessionUrl` 필드 추가
- `packages/cctv/src/whep/client.ts` — `parseOffer()`, `generateSdpFragment()`, `sendLocalCandidates()` 추가, `performWhepNegotiation()` ICE Trickle 지원

## Test plan
- [ ] 기존 WHEP 연결 동작 확인 (ICE Trickle 미지원 서버)
- [ ] ICE Trickle 지원 서버에서 candidate 전달 확인
- [ ] `pnpm --filter @pf-dev/cctv type-check` 통과
- [ ] `pnpm --filter @pf-dev/cctv lint` 통과