### PR TITLE
fix(cctv): WHEP session URL 파싱 에러 수정

### DIFF
--- a/apps/yongin-platform-app/CHANGELOG.md
+++ b/apps/yongin-platform-app/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @pf-dev/yongin-platform-app
+
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @pf-dev/cctv@0.2.1

--- a/apps/yongin-platform-app/package.json
+++ b/apps/yongin-platform-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pf-dev/yongin-platform-app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cctv/CHANGELOG.md
+++ b/packages/cctv/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pf-dev/cctv
 
+## 0.2.1
+
+### Patch Changes
+
+- WHEP session URL 파싱 시 `new URL(locationHeader, streamUrl)`이 상대 경로 `streamUrl`을 base로 받으면 TypeError를 던지는 문제 수정. try/catch로 감싸서 프록시 환경에서는 ICE trickle을 스킵하고 연결은 정상 동작하도록 변경.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/cctv/package.json
+++ b/packages/cctv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pf-dev/cctv",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/cctv/src/whep/client.ts
+++ b/packages/cctv/src/whep/client.ts
@@ -103,7 +103,13 @@ export async function performWhepNegotiation(
 
   const locationHeader = response.headers.get("location");
   if (locationHeader) {
-    sessionUrl = new URL(locationHeader, streamUrl).toString();
+    try {
+      sessionUrl = new URL(locationHeader, streamUrl).toString();
+    } catch {
+      console.warn(
+        "[WHEP] ICE trickle disabled — cannot resolve session URL from relative streamUrl"
+      );
+    }
   }
 
   const answerSdp = await response.text();


### PR DESCRIPTION
## Summary

- `new URL(locationHeader, streamUrl)`이 상대 경로 `streamUrl`을 base로 받으면 TypeError를 던지는 문제 수정
- try/catch로 감싸서 프록시 환경에서는 ICE trickle을 스킵하고 WHEP 연결은 정상 동작하도록 변경
- `@pf-dev/cctv` 0.2.0 → 0.2.1 패치 릴리즈

## Changes

- `packages/cctv/src/whep/client.ts` — `new URL` try/catch 추가
- Changeset version bump: `@pf-dev/cctv@0.2.1`