### PR TITLE
#357 #358 #359 - fix(yongin-app): APP 위젯 UI 디자인 시안 일치

### DIFF
--- a/apps/yongin-platform-app/src/components/widgets/Announcement.tsx
+++ b/apps/yongin-platform-app/src/components/widgets/Announcement.tsx
@@ -43,22 +43,22 @@ export function Announcement({ id, className }: BaseWidgetProps) {
     <Widget id={id} className={cn(className)} contentClassName="h-full flex flex-col p-4">
       {/* 헤더 */}
       <div className="flex items-center justify-between mb-3">
-        <h3 className="font-bold text-lg">공지사항</h3>
+        <h3 className="font-bold text-[16px] text-[#333] tracking-[-0.16px]">공지사항</h3>
         {total > 1 && (
           <div className="flex">
             <button
               onClick={goPrev}
-              className="w-7 h-7 flex items-center justify-center rounded-l border border-gray-300 hover:bg-gray-100 transition-colors"
+              className="w-6 h-5 flex items-center justify-center rounded-l-[10px] rounded-r-none border border-[#BBBFCF] hover:bg-gray-100 transition-colors"
               aria-label="이전 공지"
             >
-              <img src={arrowPrevIcon} alt="" className="w-4 h-4" />
+              <img src={arrowPrevIcon} alt="" className="w-3.5 h-3.5" />
             </button>
             <button
               onClick={goNext}
-              className="w-7 h-7 flex items-center justify-center rounded-r border border-l-0 border-gray-300 hover:bg-gray-100 transition-colors"
+              className="w-6 h-5 flex items-center justify-center rounded-r-[10px] rounded-l-none border border-l-0 border-[#BBBFCF] hover:bg-gray-100 transition-colors"
               aria-label="다음 공지"
             >
-              <img src={arrowNextIcon} alt="" className="w-4 h-4" />
+              <img src={arrowNextIcon} alt="" className="w-3.5 h-3.5" />
             </button>
           </div>
         )}
@@ -68,7 +68,6 @@ export function Announcement({ id, className }: BaseWidgetProps) {
       {isLoading && (
         <div className="flex-1 space-y-2">
           <div className="h-5 w-28 bg-gray-200 rounded animate-pulse" />
-          <div className="h-px w-full bg-gray-200" />
           <div className="h-3 w-full bg-gray-200 rounded animate-pulse" />
           <div className="h-3 w-3/4 bg-gray-200 rounded animate-pulse" />
         </div>
@@ -88,12 +87,12 @@ export function Announcement({ id, className }: BaseWidgetProps) {
 
       {!isLoading && !isError && notice && (
         <div className="flex-1 min-h-0 flex flex-col">
-          <p className="font-bold text-sm text-gray-800 mb-1">{notice.title}</p>
-          <p className="text-xs text-gray-400 mb-2">{formatDate(notice.updatedAt)}</p>
-          <hr className="border-gray-200 mb-2" />
-          <div className="flex-1 min-h-0 overflow-y-auto text-sm text-gray-600 leading-relaxed">
+          <p className="font-bold text-[14px] text-[#030303] mb-[23px]">
+            {formatDate(notice.updatedAt)}
+          </p>
+          <div className="flex-1 min-h-0 overflow-y-auto text-[12px] text-[#555] leading-[20px] tracking-[-0.12px]">
             <p className="indent-[-0.75em] pl-3">
-              <span className="text-gray-400 mr-1">•</span>
+              <span className="text-[#555] mr-1">&bull;</span>
               {notice.content}
             </p>
           </div>

--- a/apps/yongin-platform-app/src/components/widgets/ProcessStatus.tsx
+++ b/apps/yongin-platform-app/src/components/widgets/ProcessStatus.tsx
@@ -1,67 +1,38 @@
 import { Widget, Spinner } from "@pf-dev/ui";
-import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
 import { ProcessStatusProps } from "./types";
 import { useProcessStatus } from "@/hooks/useProcessStatus";
 
-const COLORS = {
-  planned: "#94A3B8", // slate-400
-  actual: "#3B82F6", // blue-500
-  background: "#E2E8F0", // slate-200
-};
-
 function OverallSection({ plannedRate, actualRate }: { plannedRate: number; actualRate: number }) {
-  const gaugeData = [
-    { name: "actual", value: actualRate },
-    { name: "remaining", value: 100 - actualRate },
-  ];
-
   return (
-    <div className="flex items-center gap-3">
-      <div className="relative h-14 w-14 shrink-0">
-        <ResponsiveContainer width="100%" height="100%">
-          <PieChart>
-            <Pie
-              data={gaugeData}
-              cx="50%"
-              cy="50%"
-              innerRadius={18}
-              outerRadius={26}
-              startAngle={90}
-              endAngle={-270}
-              dataKey="value"
-              stroke="none"
-            >
-              <Cell fill={COLORS.actual} />
-              <Cell fill={COLORS.background} />
-            </Pie>
-          </PieChart>
-        </ResponsiveContainer>
-        <div className="absolute inset-0 flex items-center justify-center">
-          <span className="text-[11px] font-bold text-blue-600">{actualRate}%</span>
-        </div>
-      </div>
-      <div className="flex flex-1 flex-col gap-1.5">
-        <div className="flex items-center gap-1.5">
-          <span className="w-7 shrink-0 text-[10px] text-gray-500">목표</span>
-          <div className="relative h-3 flex-1 overflow-hidden rounded-full bg-gray-100">
-            <div
-              className="absolute inset-y-0 left-0 rounded-full transition-all"
-              style={{ width: `${Math.min(plannedRate, 100)}%`, backgroundColor: COLORS.planned }}
-            />
-          </div>
-          <span className="w-8 shrink-0 text-right text-[10px] font-semibold text-gray-700">
+    <div className="flex flex-col gap-[10px]">
+      {/* 목표 바 */}
+      <div className="flex items-center gap-2">
+        <span className="w-[30px] shrink-0 text-[14px] font-bold text-[#55596C]">목표</span>
+        <div className="relative h-[16px] flex-1 rounded-[8px] bg-[#E7E7E7]">
+          <div
+            className="h-full rounded-[8px]"
+            style={{
+              width: `${Math.min(plannedRate, 100)}%`,
+              background: "linear-gradient(to right, #CACACA, #646464)",
+            }}
+          />
+          <span className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-white">
             {plannedRate}%
           </span>
         </div>
-        <div className="flex items-center gap-1.5">
-          <span className="w-7 shrink-0 text-[10px] text-gray-500">실적</span>
-          <div className="relative h-3 flex-1 overflow-hidden rounded-full bg-gray-100">
-            <div
-              className="absolute inset-y-0 left-0 rounded-full transition-all"
-              style={{ width: `${Math.min(actualRate, 100)}%`, backgroundColor: COLORS.actual }}
-            />
-          </div>
-          <span className="w-8 shrink-0 text-right text-[10px] font-semibold text-blue-600">
+      </div>
+      {/* 실적 바 */}
+      <div className="flex items-center gap-2">
+        <span className="w-[30px] shrink-0 text-[14px] font-bold text-[#55596C]">실적</span>
+        <div className="relative h-[16px] flex-1 rounded-[8px] bg-[#E7E7E7]">
+          <div
+            className="h-full rounded-[8px]"
+            style={{
+              width: `${Math.min(actualRate, 100)}%`,
+              background: "linear-gradient(to right, #FFB033, #F37021)",
+            }}
+          />
+          <span className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-white">
             {actualRate}%
           </span>
         </div>
@@ -73,31 +44,30 @@ function OverallSection({ plannedRate, actualRate }: { plannedRate: number; actu
 function ProgressBar({
   label,
   actualRate,
-  plannedRate,
+  isLast,
 }: {
   label: string;
   actualRate: number;
-  plannedRate: number;
+  isLast: boolean;
 }) {
   return (
-    <div className="flex items-center gap-2">
-      <span className="w-16 shrink-0 truncate text-xs text-gray-600" title={label}>
+    <div
+      className={
+        isLast
+          ? "flex items-center gap-2 pb-[6px]"
+          : "flex items-center gap-2 pb-[6px] border-b border-[#E7E7E7]"
+      }
+    >
+      <span className="w-[60px] shrink-0 truncate text-[12px] text-[#333]" title={label}>
         {label}
       </span>
-      <div className="relative h-3.5 flex-1 overflow-hidden rounded-full bg-gray-100">
+      <div className="relative h-[3px] flex-1 rounded-full bg-[#CCC]">
         <div
-          className="absolute inset-y-0 left-0 rounded-full bg-blue-500 transition-all"
+          className="absolute inset-y-0 left-0 rounded-full bg-[#333]"
           style={{ width: `${Math.min(actualRate, 100)}%` }}
         />
-        <div
-          className="absolute inset-y-0 w-0.5 bg-gray-400"
-          style={{ left: `${Math.min(plannedRate, 100)}%` }}
-          title={`목표: ${plannedRate}%`}
-        />
       </div>
-      <span className="w-10 shrink-0 text-right text-xs font-medium text-gray-700">
-        {actualRate}%
-      </span>
+      <span className="w-[32px] shrink-0 text-right text-[12px] text-[#55596C]">{actualRate}%</span>
     </div>
   );
 }
@@ -132,20 +102,19 @@ export function ProcessStatus({ id, className }: ProcessStatusProps) {
   return (
     <Widget id={id} className={className} contentClassName="h-full">
       <div className="flex flex-col h-full">
-        <div className="flex flex-col gap-1.5 shrink-0">
-          <div className="font-bold text-sm">공정현황</div>
+        <div className="flex flex-col gap-[10px] shrink-0">
+          <div className="font-bold text-[16px] text-[#333] tracking-[-0.16px]">공정현황</div>
           <OverallSection plannedRate={overall.plannedRate} actualRate={overall.actualRate} />
         </div>
 
         {workStatuses.length > 0 && (
-          <div className="flex flex-col gap-1.5 min-h-0 flex-1 overflow-y-auto border-t border-gray-100 mt-3 pt-2">
-            <div className="text-[11px] font-semibold text-gray-500 shrink-0">개별 공종</div>
-            {workStatuses.map((ws) => (
+          <div className="flex flex-col gap-[6px] min-h-0 flex-1 overflow-y-auto mt-3 pt-2">
+            {workStatuses.map((ws, index) => (
               <ProgressBar
                 key={ws.id}
                 label={ws.workTypeName}
                 actualRate={ws.actualRate}
-                plannedRate={ws.plannedRate}
+                isLast={index === workStatuses.length - 1}
               />
             ))}
           </div>

--- a/apps/yongin-platform-app/src/layouts/Header.tsx
+++ b/apps/yongin-platform-app/src/layouts/Header.tsx
@@ -72,7 +72,7 @@ export function Header() {
                 variant="ghost"
                 size="icon"
                 aria-label="관리자 페이지로 이동"
-                onClick={() => (window.location.href = ADMIN_URL)}
+                onClick={() => window.open(ADMIN_URL, "_blank", "noopener,noreferrer")}
                 className="bg-white/50 rounded-[0.9375rem] border border-[#999] w-10 h-10"
               >
                 <Settings size="lg" className="text-gray-600" />


### PR DESCRIPTION
## 개요
용인 플랫폼 앱의 공정현황, 공지사항 위젯을 디자인 시안에 맞게 수정하고, 관리자 페이지 새탭 열기에 보안 속성을 추가합니다.

## 변경사항
- **#357 공정현황**: 도넛 차트(Recharts) → 수평 그라디언트 프로그레스 바, 개별 공종 리스트 스타일 시안 일치
- **#358 공지사항**: title 제거, 날짜 14px bold 강조, 네비 버튼 축소(w-6 h-5), 본문 12px 스타일 시안 일치
- **#359 관리자 새탭**: `window.open`에 `noopener,noreferrer` 보안 속성 추가

## 테스트
- [x] 공정현황 위젯: 그라디언트 바 렌더링, 퍼센트 표시, 개별 공종 리스트 확인
- [x] 공지사항 위젯: 날짜 표시, 좌우 네비게이션, 자동 롤링 동작 확인
- [x] 관리자 버튼: 새 탭 열기 동작 확인

## 체크리스트
- [x] 빌드 성공
- [x] 린트 통과

## 관련 이슈
Closes #357
Closes #358
Closes #359