### PR TITLE
#363 - fix(yongin-app): 목표관리 Active 상태 미반영 및 공지사항 줄바꿈 정렬

### DIFF
--- a/apps/yongin-platform-app/src/components/widgets/Announcement.tsx
+++ b/apps/yongin-platform-app/src/components/widgets/Announcement.tsx
@@ -90,10 +90,15 @@ export function Announcement({ id, className }: BaseWidgetProps) {
             {formatDate(notice.updatedAt)}
           </p>
           <div className="flex-1 min-h-0 overflow-y-auto text-[12px] text-[#555] leading-[20px] tracking-[-0.12px]">
-            <p className="indent-[-0.75em] pl-3">
-              <span className="text-[#555] mr-1">&bull;</span>
-              {notice.content}
-            </p>
+            {notice.content
+              .split("\n")
+              .filter(Boolean)
+              .map((line, i) => (
+                <p key={i} className="indent-[-0.75em] pl-3">
+                  <span className="text-[#555] mr-1">&bull;</span>
+                  {line}
+                </p>
+              ))}
           </div>
         </div>
       )}

--- a/apps/yongin-platform-app/src/hooks/useGoal.ts
+++ b/apps/yongin-platform-app/src/hooks/useGoal.ts
@@ -9,7 +9,7 @@ export function useGoal() {
   });
 
   return {
-    goals: data ?? [],
+    goals: (data ?? []).filter((g) => g.isActive),
     isLoading,
     isError: !!error,
     error,

--- a/apps/yongin-platform-app/src/services/goal.service.ts
+++ b/apps/yongin-platform-app/src/services/goal.service.ts
@@ -19,6 +19,7 @@ function toGoalData(response: GoalResponse): GoalData {
     plannedWorkDays: response.plannedWorkDays,
     completionDate: response.completionDate,
     delayDays: response.delayDays,
+    isActive: response.isActive,
   };
 }
 

--- a/apps/yongin-platform-app/src/services/types/goal.ts
+++ b/apps/yongin-platform-app/src/services/types/goal.ts
@@ -21,6 +21,7 @@ export interface GoalResponse {
   completionDate: string;
   plannedWorkDays: number;
   delayDays: number;
+  isActive: boolean;
 }
 
 // 앱에서 사용할 타입
@@ -40,4 +41,5 @@ export interface GoalData {
   plannedWorkDays: number;
   completionDate: string;
   delayDays: number;
+  isActive: boolean;
 }


### PR DESCRIPTION
## Summary
- 목표관리 `isActive` 필드 추가 및 Active 항목만 APP에 노출되도록 필터링
- 공지사항 `content`를 줄바꿈(`\n`) 기준으로 split하여 각 줄을 bullet(`•`)로 정렬

## Test plan
- [ ] 관리자에서 목표관리 항목 Active/Inactive 설정 후 APP 위젯에서 Active 항목만 노출되는지 확인
- [ ] 관리자에서 공지사항에 줄바꿈 포함 입력 후 APP 위젯에서 각 줄이 bullet로 정렬되는지 확인
- [ ] 빌드 통과 확인

Closes #363